### PR TITLE
Add support for instance mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,24 @@ function draw(){
 }
 ```
 
+### Instance mode
+
+The library can also be used in p5 instance mode.
+
+```
+import p5plot from 'p5.plotsvg';
+
+function sketch(context) {
+  context.setup = function() {
+    context.createCanvas(400, 400);    
+    p5plot.beginRecordSVG(context, "output.svg");
+    context.circle(200, 200, 200);
+    p5plot.endRecordSVG();
+  };
+};
+
+new p5(sketch, document.getElementById("container"));
+```
 
 ---
 ## What the p5.plotSvg library *IS*: 
@@ -200,4 +218,4 @@ Pen plotters, vector output, plotter art, p5.js, SVG, #plotterTwitter, creative 
 This project was made possible by support from the [CMU School of Art](https://art.cmu.edu/), the [Frank-Ratchye STUDIO for Creative Inquiry](https://studioforcreativeinquiry.org) at Carnegie Mellon University, and [Bantam Tools](https://www.bantamtools.com/).
 
 <img src="images/cmu_school_of_art_logo.png" height="55"> <img src="images/studio_logo.png" height="55"> <img src="images/bantam_tools_logo.png" height="55">
-
+

--- a/lib/p5.plotSvg.js
+++ b/lib/p5.plotSvg.js
@@ -223,38 +223,38 @@
    * Reverts all overrides, returning p5.js functions to their standard behavior.
    */
   function restoreP5Functions(){
-    window.arc = _originalArcFunc;
-    window.bezier = _originalBezierFunc;
-    window.circle = _originalCircleFunc;
-    window.curve = _originalCurveFunc;
-    window.ellipse = _originalEllipseFunc;
-    window.line = _originalLineFunc;
-    window.point = _originalPointFunc;
-    window.quad = _originalQuadFunc;
-    window.rect = _originalRectFunc;
-    window.square = _originalSquareFunc;
-    window.triangle = _originalTriangleFunc;
-    window.bezierDetail = _originalBezierDetailFunc;
-    window.curveTightness = _originalCurveTightnessFunc;
+    _p5Instance.arc = _originalArcFunc;
+    _p5Instance.bezier = _originalBezierFunc;
+    _p5Instance.circle = _originalCircleFunc;
+    _p5Instance.curve = _originalCurveFunc;
+    _p5Instance.ellipse = _originalEllipseFunc;
+    _p5Instance.line = _originalLineFunc;
+    _p5Instance.point = _originalPointFunc;
+    _p5Instance.quad = _originalQuadFunc;
+    _p5Instance.rect = _originalRectFunc;
+    _p5Instance.square = _originalSquareFunc;
+    _p5Instance.triangle = _originalTriangleFunc;
+    _p5Instance.bezierDetail = _originalBezierDetailFunc;
+    _p5Instance.curveTightness = _originalCurveTightnessFunc;
     
-    window.beginShape = _originalBeginShapeFunc;
-    window.vertex = _originalVertexFunc;
-    window.bezierVertex = _originalBezierVertexFunc;
-    window.quadraticVertex = _originalQuadraticVertexFunc;
-    window.curveVertex = _originalCurveVertexFunc; 
-    window.endShape = _originalEndShapeFunc; 
+    _p5Instance.beginShape = _originalBeginShapeFunc;
+    _p5Instance.vertex = _originalVertexFunc;
+    _p5Instance.bezierVertex = _originalBezierVertexFunc;
+    _p5Instance.quadraticVertex = _originalQuadraticVertexFunc;
+    _p5Instance.curveVertex = _originalCurveVertexFunc; 
+    _p5Instance.endShape = _originalEndShapeFunc; 
     
-    window.describe = _originalDescribeFunc; 
-    window.push = _originalPushFunc; 
-    window.pop = _originalPopFunc; 
-    window.scale = _originalScaleFunc; 
-    window.translate = _originalTranslateFunc; 
-    window.rotate = _originalRotateFunc;
-    window.shearX = _originalShearXFunc;
-    window.shearY = _originalShearYFunc;
-    window.text = _originalTextFunc;
-    window.stroke = _originalStrokeFunc; 
-    window.colorMode = _originalColorModeFunc; 
+    _p5Instance.describe = _originalDescribeFunc; 
+    _p5Instance.push = _originalPushFunc; 
+    _p5Instance.pop = _originalPopFunc; 
+    _p5Instance.scale = _originalScaleFunc; 
+    _p5Instance.translate = _originalTranslateFunc; 
+    _p5Instance.rotate = _originalRotateFunc;
+    _p5Instance.shearX = _originalShearXFunc;
+    _p5Instance.shearY = _originalShearYFunc;
+    _p5Instance.text = _originalTextFunc;
+    _p5Instance.stroke = _originalStrokeFunc; 
+    _p5Instance.colorMode = _originalColorModeFunc; 
   }
 
 
@@ -266,8 +266,8 @@
    * @see {@link https://p5js.org/reference/p5/arc/}
    */
   function overrideArcFunction() {
-    _originalArcFunc = window.arc;
-    window.arc = function(x, y, w, h, start, stop, mode = OPEN, detail = 0) {
+    _originalArcFunc = _p5Instance.arc;
+    _p5Instance.arc = function(x, y, w, h, start, stop, mode = OPEN, detail = 0) {
       if (_bRecordingSvg) {
         if (detail !== undefined && p5.instance._renderer.drawingContext instanceof WebGLRenderingContext) {
           console.warn("arc() detail is currently unsupported in SVG output.");
@@ -287,8 +287,8 @@
    * @see {@link https://p5js.org/reference/p5/bezier/}
    */
   function overrideBezierFunction(){
-    _originalBezierFunc = window.bezier;
-    window.bezier = function(x1, y1, x2, y2, x3, y3, x4, y4) {
+    _originalBezierFunc = _p5Instance.bezier;
+    _p5Instance.bezier = function(x1, y1, x2, y2, x3, y3, x4, y4) {
       if (_bRecordingSvg) {
         let transformMatrix = captureCurrentTransformMatrix();
         _commands.push({ type: 'bezier', x1, y1, x2, y2, x3, y3, x4, y4, transformMatrix });
@@ -307,8 +307,8 @@
    * @see {@link https://p5js.org/reference/p5/circle/}
    */
   function overrideCircleFunction(){
-    _originalCircleFunc = window.circle;
-    window.circle = function(x, y, d) {
+    _originalCircleFunc = _p5Instance.circle;
+    _p5Instance.circle = function(x, y, d) {
       if (_bRecordingSvg) { 
         let transformMatrix = captureCurrentTransformMatrix();
         
@@ -343,8 +343,8 @@
    * @see {@link https://p5js.org/reference/#/p5/curve}
    */
   function overrideCurveFunction() {
-    _originalCurveFunc = window.curve;
-    window.curve = function(x1, y1, x2, y2, x3, y3, x4, y4) {
+    _originalCurveFunc = _p5Instance.curve;
+    _p5Instance.curve = function(x1, y1, x2, y2, x3, y3, x4, y4) {
       if (_bRecordingSvg) {
         
         // Adjust control points based on the current tightness setting
@@ -372,8 +372,8 @@
    * @see {@link https://p5js.org/reference/p5/ellipse/}
   */
   function overrideEllipseFunction(){
-    _originalEllipseFunc = window.ellipse;
-    window.ellipse = function(x, y, w, h, detail = 0) {
+    _originalEllipseFunc = _p5Instance.ellipse;
+    _p5Instance.ellipse = function(x, y, w, h, detail = 0) {
       if (_bRecordingSvg) {
         if (detail !== undefined && _p5Instance._renderer.drawingContext instanceof WebGLRenderingContext) {
           console.warn("ellipse() detail is currently unsupported in SVG output.");
@@ -415,8 +415,8 @@
    * @see {@link https://p5js.org/reference/p5/line/}
    */
   function overrideLineFunction() {
-    _originalLineFunc = window.line;
-    window.line = function(x1, y1, x2, y2) {
+    _originalLineFunc = _p5Instance.line;
+    _p5Instance.line = function(x1, y1, x2, y2) {
       if (_bRecordingSvg) { 
         let transformMatrix = captureCurrentTransformMatrix();
         _commands.push({ type: 'line', x1, y1, x2, y2, transformMatrix });
@@ -433,8 +433,8 @@
    * @see {@link https://p5js.org/reference/p5/point/}
    */
   function overridePointFunction() {
-    _originalPointFunc = window.point;
-    window.point = function(x, y) {
+    _originalPointFunc = _p5Instance.point;
+    _p5Instance.point = function(x, y) {
       if (_bRecordingSvg) {
         let transformMatrix = captureCurrentTransformMatrix();
         _commands.push({ type: 'point', x, y, radius: _svgPointRadius, transformMatrix });
@@ -451,8 +451,8 @@
    * @see {@link https://p5js.org/reference/p5/quad/}
    */
   function overrideQuadFunction(){
-    _originalQuadFunc = window.quad;
-    window.quad = function(x1, y1, x2, y2, x3, y3, x4, y4) {
+    _originalQuadFunc = _p5Instance.quad;
+    _p5Instance.quad = function(x1, y1, x2, y2, x3, y3, x4, y4) {
       if (_bRecordingSvg) { 
         let transformMatrix = captureCurrentTransformMatrix();
         _commands.push({ type: 'quad', x1, y1, x2, y2, x3, y3, x4, y4, transformMatrix });
@@ -471,8 +471,8 @@
    * @see {@link https://p5js.org/reference/p5/rect/}
    */
   function overrideRectFunction() {
-    _originalRectFunc = window.rect;
-    window.rect = function(x, y, w, h, tl, tr, br, bl) {
+    _originalRectFunc = _p5Instance.rect;
+    _p5Instance.rect = function(x, y, w, h, tl, tr, br, bl) {
       if (_bRecordingSvg) {
         if (arguments.length === 3) { h = w; }
         
@@ -523,8 +523,8 @@
    * @see {@link https://p5js.org/reference/p5/square/}
    */
   function overrideSquareFunction(){
-    _originalSquareFunc = window.square;
-    window.square = function(x, y, s, tl,tr,br,bl) {
+    _originalSquareFunc = _p5Instance.square;
+    _p5Instance.square = function(x, y, s, tl,tr,br,bl) {
       if (_bRecordingSvg) { 
         let w = s; 
         let h = s; 
@@ -571,8 +571,8 @@
    * @see {@link https://p5js.org/reference/p5/triangle/}
    */
   function overrideTriangleFunction(){
-    _originalTriangleFunc = window.triangle;
-    window.triangle = function(x1, y1, x2, y2, x3, y3) {
+    _originalTriangleFunc = _p5Instance.triangle;
+    _p5Instance.triangle = function(x1, y1, x2, y2, x3, y3) {
       if (_bRecordingSvg) {
         let transformMatrix = captureCurrentTransformMatrix();
         _commands.push({ type: 'triangle', x1, y1, x2, y2, x3, y3, transformMatrix });
@@ -589,8 +589,8 @@
    * https://p5js.org/reference/p5/bezierDetail/
    */
   function overrideBezierDetailFunction() {
-    _originalBezierDetailFunc = window.bezierDetail;
-    window.bezierDetail = function(detailLevel) { // Check if the renderer is WEBGL
+    _originalBezierDetailFunc = _p5Instance.bezierDetail;
+    _p5Instance.bezierDetail = function(detailLevel) { // Check if the renderer is WEBGL
       if (p5.instance._renderer.drawingContext instanceof WebGLRenderingContext) {
         console.warn("bezierDetail() is currently unsupported in SVG output.");
       }
@@ -606,8 +606,8 @@
    * @see {@link https://p5js.org/reference/p5/curveTightness/}
    */
   function overrideCurveTightnessFunction() {
-    _originalCurveTightnessFunc = window.curveTightness;
-    window.curveTightness = function(tightness) {
+    _originalCurveTightnessFunc = _p5Instance.curveTightness;
+    _p5Instance.curveTightness = function(tightness) {
       if (_bRecordingSvg) { 
         _svgCurveTightness = tightness;
       }
@@ -623,8 +623,8 @@
    * @see {@link https://p5js.org/reference/p5/beginShape/}
    */
   function overrideBeginShapeFunction() {
-    _originalBeginShapeFunc = window.beginShape;
-    window.beginShape = function(kind) {
+    _originalBeginShapeFunc = _p5Instance.beginShape;
+    _p5Instance.beginShape = function(kind) {
       if (_bRecordingSvg) { 
         _vertexStack = []; // Start with an empty vertex stack
         _shapeMode = "simple"; // Assume simple mode initially
@@ -649,8 +649,8 @@
    * @see {@link https://p5js.org/reference/p5/vertex/}
    */
   function overrideVertexFunction() {
-    _originalVertexFunc = window.vertex;
-    window.vertex = function(x, y) {
+    _originalVertexFunc = _p5Instance.vertex;
+    _p5Instance.vertex = function(x, y) {
       if (_bRecordingSvg) {
         _vertexStack.push({ type: 'vertex', x, y });
       }
@@ -667,8 +667,8 @@
    */
   function overrideBezierVertexFunction() {
     // Override `bezierVertex()` and mark shape as complex
-    _originalBezierVertexFunc = window.bezierVertex;
-    window.bezierVertex = function(x2, y2, x3, y3, x4, y4) {
+    _originalBezierVertexFunc = _p5Instance.bezierVertex;
+    _p5Instance.bezierVertex = function(x2, y2, x3, y3, x4, y4) {
       if (_bRecordingSvg) {
         _shapeMode = 'complex'; // Switch to complex mode
         _vertexStack.push({ type: 'bezier', x2, y2, x3, y3, x4, y4 });
@@ -686,8 +686,8 @@
    */
   function overrideQuadraticVertexFunction() {
     // Override `quadraticVertex()` and mark shape as complex
-    _originalQuadraticVertexFunc = window.quadraticVertex;
-    window.quadraticVertex = function(cx, cy, x, y) {
+    _originalQuadraticVertexFunc = _p5Instance.quadraticVertex;
+    _p5Instance.quadraticVertex = function(cx, cy, x, y) {
       if (_bRecordingSvg) {
         _shapeMode = 'complex'; // Switch to complex mode
         _vertexStack.push({ type: 'quadratic', cx, cy, x, y });
@@ -705,8 +705,8 @@
    */
   function overrideCurveVertexFunction() {
     // Override `curveVertex()` and mark shape as complex
-    _originalCurveVertexFunc = window.curveVertex;
-    window.curveVertex = function(x, y) {
+    _originalCurveVertexFunc = _p5Instance.curveVertex;
+    _p5Instance.curveVertex = function(x, y) {
       if (_bRecordingSvg) {
         _shapeMode = 'complex'; // Switch to complex mode
         
@@ -740,8 +740,8 @@
    * @see {@link https://p5js.org/reference/p5/endShape/}
    */
   function overrideEndShapeFunction() {
-    _originalEndShapeFunc = window.endShape;
-    window.endShape = function(mode) {
+    _originalEndShapeFunc = _p5Instance.endShape;
+    _p5Instance.endShape = function(mode) {
       if (_bRecordingSvg && _vertexStack.length > 0) {
         let transformMatrix = captureCurrentTransformMatrix();
         
@@ -807,8 +807,8 @@
    * @see {@link https://p5js.org/reference/p5/describe/}
    */
   function overrideDescribeFunction() {
-    _originalDescribeFunc = window.describe;
-    window.describe = function(description) {
+    _originalDescribeFunc = _p5Instance.describe;
+    _p5Instance.describe = function(description) {
       if (_bRecordingSvg) {
         if (description && description.trim().length > 0){
           // Push a command to the stack for generating an SVG `desc` element
@@ -827,9 +827,9 @@
    * @see {@link https://p5js.org/reference/p5/push/}
    */
   function overridePushFunction(){
-    _originalPushFunc = window.push;
+    _originalPushFunc = _p5Instance.push;
     _bTransformsExist = true; 
-    window.push = function() {
+    _p5Instance.push = function() {
       if (_bRecordingSvg) {
         _commands.push({ type: 'push' });
       }
@@ -845,9 +845,9 @@
    * @see {@link https://p5js.org/reference/p5/pop/}
    */
   function overridePopFunction(){
-    _originalPopFunc = window.pop;
+    _originalPopFunc = _p5Instance.pop;
     _bTransformsExist = true; 
-    window.pop = function() {
+    _p5Instance.pop = function() {
       if (_bRecordingSvg) {
         _commands.push({ type: 'pop' });
       }
@@ -863,9 +863,9 @@
    * @see {@link https://p5js.org/reference/p5/scale/}
    */
   function overrideScaleFunction(){
-    _originalScaleFunc = window.scale;
+    _originalScaleFunc = _p5Instance.scale;
     _bTransformsExist = true; 
-    window.scale = function(sx, sy) {
+    _p5Instance.scale = function(sx, sy) {
       if (_bRecordingSvg) {
         _commands.push({ type: 'scale', sx, sy: sy || sx });
       }
@@ -881,9 +881,9 @@
    * @see {@link https://p5js.org/reference/p5/translate/}
    */
   function overrideTranslateFunction(){
-    _originalTranslateFunc = window.translate;
+    _originalTranslateFunc = _p5Instance.translate;
     _bTransformsExist = true; 
-    window.translate = function(tx, ty) {
+    _p5Instance.translate = function(tx, ty) {
       if (_bRecordingSvg) {
         _commands.push({ type: 'translate', tx, ty });
       }
@@ -899,9 +899,9 @@
    * https://p5js.org/reference/p5/rotate/
    */
   function overrideRotateFunction(){
-    _originalRotateFunc = window.rotate;
+    _originalRotateFunc = _p5Instance.rotate;
     _bTransformsExist = true; 
-    window.rotate = function(angle) {
+    _p5Instance.rotate = function(angle) {
       if (_bRecordingSvg) {
         _commands.push({ type: 'rotate', angle });
       }
@@ -917,9 +917,9 @@
    * @see {@link https://p5js.org/reference/p5/shearX/}
    */
   function overrideShearXFunction(){
-    _originalShearXFunc = window.shearX;
+    _originalShearXFunc = _p5Instance.shearX;
     _bTransformsExist = true; 
-    window.shearX = function(angle) {
+    _p5Instance.shearX = function(angle) {
       if (_bRecordingSvg) {
         _commands.push({ type: 'shearx', angle });
       }
@@ -935,9 +935,9 @@
    * @see {@link https://p5js.org/reference/p5/shearY/}
    */
   function overrideShearYFunction(){
-    _originalShearYFunc = window.shearY;
+    _originalShearYFunc = _p5Instance.shearY;
     _bTransformsExist = true; 
-    window.shearY = function(angle) {
+    _p5Instance.shearY = function(angle) {
       if (_bRecordingSvg) {
         _commands.push({ type: 'sheary', angle });
       }
@@ -955,8 +955,8 @@
    * @see {@link https://p5js.org/reference/p5/text/}
    */
   function overrideTextFunction() {
-    _originalTextFunc = window.text;
-    window.text = function(content, x, y, maxWidth, maxHeight) {
+    _originalTextFunc = _p5Instance.text;
+    _p5Instance.text = function(content, x, y, maxWidth, maxHeight) {
       if (_bRecordingSvg) {
         // Warn if maxWidth or maxHeight are provided
         if (typeof maxWidth !== 'undefined' || typeof maxHeight !== 'undefined') {
@@ -2518,8 +2518,8 @@
    * whose values are in the range of 0-255 are supported.
    */
   function overrideColorModeFunction() {
-    _originalColorModeFunc = window.colorMode;
-    window.colorMode = function() {
+    _originalColorModeFunc = _p5Instance.colorMode;
+    _p5Instance.colorMode = function() {
       console.warn("p5.plotSvg: Only CSS named colors, hex colors, and RGB/gray colors whose values are in the range of 0-255 are supported for SVG output.");
       _originalColorModeFunc.apply(this, arguments);
     };
@@ -2535,8 +2535,8 @@
    * hex colors, or RGB/gray values.
    */
   function overrideStrokeFunction() {
-    _originalStrokeFunc = window.stroke;
-    window.stroke = function(...args) {
+    _originalStrokeFunc = _p5Instance.stroke;
+    _p5Instance.stroke = function(...args) {
       if (_bRecordingSvg) {
         let scol;
 

--- a/lib/p5.plotSvg.js
+++ b/lib/p5.plotSvg.js
@@ -1167,7 +1167,6 @@
     svgContent = ""; 
     _commands = [];
     _vertexStack = []; 
-    _transformStack = [];
   }
 
 


### PR DESCRIPTION
This pull request enhances the p5.plotSvg library to support p5.js instance mode.

Previously, the library only worked with p5.js global mode, which limited its compatibility with modern web applications.

## Changes

- Updated override functions to preserve and override the function from the local `_p5Instance` object instead of the global `window` object.
- Updated restore function to restore functions on the local `_p5Instance` object instead of the global `window` object.
- Also includes a bug fix where a non-existant and unused variable `_transformStack` is assigned

## Why this matters

p5.js offers two primary modes of operation:
- **Global mode:** p5.js functions are available globally (e.g., `circle()`, `line()`).
- **Instance mode:** p5.js functions are methods of a specific p5 instance (e.g., `p.circle()`, `p.line()`).

Instance mode is necessary for:
- Applications that require multiple sketches on a single page.
- Integration in modern web applications which use a JavaScript bundler (for example, React).

This update makes p5.plotSvg compatible with both modes, thus expanding its integration capabilities without breaking previous functionality.

## Usage example

```js
import p5plot from 'p5.plotsvg';

function sketch(context) {
  context.setup = function() {
    context.createCanvas(400, 400);    
    p5plot.beginRecordSVG(context, "output.svg");
    context.circle(200, 200, 200);
    p5plot.endRecordSVG();
  };
};

new p5(sketch, document.getElementById("container"));

```

## Limitation

The same import of `p5plot` should not be used for different instances, sketches should import it in separate JavaScript module.

## Testing

The library has been verified to work correctly in both global and instance modes.

All examples in this repository are working as expected.

See live P5 sketch example: https://editor.p5js.org/Ucodia/sketches/xO8vTRzP7