### PR TITLE
Implemented option to merge named SVG groups

### DIFF
--- a/lib/p5.plotSvg.js
+++ b/lib/p5.plotSvg.js
@@ -1220,13 +1220,10 @@
 
       nodesToRemove.forEach((node) => {
         const next = node.nextSibling;
-        if (
-          next &&
-          next.nodeType === Node.TEXT_NODE &&
-          /^\s*$/.test(next.nodeValue)
-        )
+        // remove any empty text nodes left after the element to remove
+        if (next && next.nodeType === Node.TEXT_NODE && /^\s*$/.test(next.nodeValue)) {
           element.removeChild(next);
-
+        }
         element.removeChild(node);
       });
     }

--- a/lib/p5.plotSvg.js
+++ b/lib/p5.plotSvg.js
@@ -998,12 +998,6 @@
   function exportSVG() {
     let svgContent = "";
     
-    svgContent += `<!-- ${_svgFilename} -->\n`; 
-    svgContent += `<!-- Generated using p5.plotSvg: -->\n`;
-    svgContent += `<!-- A Plotter-Oriented SVG Exporter for p5.js -->\n`;
-    svgContent += `<!-- ${new Date().toString()} -->\n`;
-    svgContent += `<!-- DPI: ${_svgDPI} -->\n`;
-    
     let svgW = _bCustomSizeSet ? _svgWidth : _p5Instance.width; 
     let svgH = _bCustomSizeSet ? _svgHeight : _p5Instance.height;
     let widthInches = svgW / _svgDPI;
@@ -1163,6 +1157,13 @@
     if (_svgMergeNamedGroups) {
       svgContent = getSvgStrMergedGroups(svgContent);
     }
+
+    let headerContent = `<!-- ${_svgFilename} -->\n`; 
+    headerContent += `<!-- Generated using p5.plotSvg: -->\n`;
+    headerContent += `<!-- A Plotter-Oriented SVG Exporter for p5.js -->\n`;
+    headerContent += `<!-- ${new Date().toString()} -->\n`;
+    headerContent += `<!-- DPI: ${_svgDPI} -->\n`;
+    svgContent = headerContent + svgContent;
     
     const blob = new Blob([svgContent], { type: 'image/svg+xml' });
     const url = URL.createObjectURL(blob);

--- a/lib/p5.plotSvg.js
+++ b/lib/p5.plotSvg.js
@@ -42,6 +42,7 @@
   let _svgCurrentStrokeColor = _svgDefaultStrokeColor;
   let _svgBackgroundColor = null;
   let _svgDefaultStrokeWeight = 1;
+  let _svgMergeNamedGroups = true;
 
   // Internal variables, not to be accessed directly
   let _p5Instance; 
@@ -1158,7 +1159,11 @@
     
     svgContent += `</g>\n`; // Close the `non-scaling-stroke` group
     svgContent += `</svg>`;
-
+    
+    if (_svgMergeNamedGroups) {
+      svgContent = getSvgStrMergedGroups(svgContent);
+    }
+    
     const blob = new Blob([svgContent], { type: 'image/svg+xml' });
     const url = URL.createObjectURL(blob);
     const a = document.createElement('a');
@@ -1172,6 +1177,63 @@
     svgContent = ""; 
     _commands = [];
     _vertexStack = []; 
+  }
+
+  /**
+   * @private
+   * Merges named groups in an SVG string by combining sibling groups with the same ID.
+   * @param {string} svgString
+   * @returns A SVG string with merged named groups.
+   */
+  function getSvgStrMergedGroups(svgString){
+    const doc = new DOMParser().parseFromString(svgString, "image/svg+xml");
+
+    function processElement(element) {
+      const children = Array.from(element.children);
+      children.forEach((child) => processElement(child));
+      const groupsById = new Map();
+      const nodesToRemove = [];
+
+      children.forEach((child) => {
+        if (child.tagName === "g" && child.hasAttribute("id")) {
+          const id = child.getAttribute("id");
+          if (!groupsById.has(id)) {
+            groupsById.set(id, []);
+          }
+          groupsById.get(id).push(child);
+        }
+      });
+
+      groupsById.forEach((groups, id) => {
+        if (groups.length > 1) {
+          const firstGroup = groups[0];
+
+          for (let i = 1; i < groups.length; i++) {
+            const groupToMerge = groups[i];
+            while (groupToMerge.firstChild) {
+              firstGroup.appendChild(groupToMerge.firstChild);
+            }
+            nodesToRemove.push(groupToMerge);
+          }
+        }
+      });
+
+      nodesToRemove.forEach((node) => {
+        const next = node.nextSibling;
+        if (
+          next &&
+          next.nodeType === Node.TEXT_NODE &&
+          /^\s*$/.test(next.nodeValue)
+        )
+          element.removeChild(next);
+
+        element.removeChild(node);
+      });
+    }
+
+    processElement(doc.documentElement);
+
+    return new XMLSerializer().serializeToString(doc);
   }
 
 
@@ -1614,6 +1676,19 @@
     let transformStr = generateTransformString(cmd);
     let str = `<polygon points="${x1Str},${y1Str} ${x2Str},${y2Str} ${x3Str},${y3Str}"${styleStr}${transformStr}/>\n`;
     return str; 
+  }
+
+
+  /**
+   * Set whether or not to merge SVG groups with the same name. 
+   * @param {boolean} enabled - Enable or disables merging of named SVG groups.
+   */
+  p5plotSvg.setSvgMergeNamedGroups = function(enabled) {
+    if (enabled === true){
+      _svgMergeNamedGroups = true; 
+    } else {
+      _svgMergeNamedGroups = false; 
+    }
   }
 
 
@@ -2692,6 +2767,7 @@
   global.setSvgResolutionDPI = p5plotSvg.setSvgResolutionDPI;
   global.setSvgResolutionDPCM = p5plotSvg.setSvgResolutionDPCM;
   global.setSvgDefaultStrokeWeight = p5plotSvg.setSvgDefaultStrokeWeight;
+  global.setSvgMergeNamedGroups = p5plotSvg.setSvgMergeNamedGroups;
   global.setSvgDefaultStrokeColor = p5plotSvg.setSvgDefaultStrokeColor;
   global.setSvgBackgroundColor = p5plotSvg.setSvgBackgroundColor;
   global.setSvgIndent = p5plotSvg.setSvgIndent;


### PR DESCRIPTION
This PR implements #6 

## Changes

- Adds new public setting `setSvgMergeNamedGroups` which is enabled by default
- Adds new private function  `getSvgStrMergedGroups` which serves as a post-processing option in `exportSVG`
- Moves file header appending after all processing occurred

## Testing

Manual testing was done with a scenario of nested SVG groups.

See live P5 sketch example: https://editor.p5js.org/Ucodia/sketches/AqNCVZyys