### PR TITLE
Implement "group by stroke color" post-processing feature

### DIFF
--- a/lib/p5.plotSvg.js
+++ b/lib/p5.plotSvg.js
@@ -34,6 +34,7 @@
   let _svgBackgroundColor = null;
   let _svgDefaultStrokeWeight = 1;
   let _svgMergeNamedGroups = true;
+  let _svgGroupByStrokeColor = false;
 
   // Internal variables, not to be accessed directly
   let _p5Instance; 
@@ -1184,6 +1185,10 @@
       svgContent = getSvgStrMergedGroups(svgContent);
     }
 
+    if (_svgGroupByStrokeColor) {
+      svgContent = getSvgStrGroupByStrokeColor(svgContent);
+    }
+
     let headerContent = `<!-- ${_svgFilename} -->\n`; 
     headerContent += `<!-- Generated using p5.plotSvg v.${p5plotSvg.VERSION}: -->\n`;
     headerContent += `<!-- A Plotter-Oriented SVG Exporter for p5.js -->\n`;
@@ -1283,6 +1288,76 @@
     return new XMLSerializer().serializeToString(doc);
   }
 
+  /**
+   * @private
+   * Group sibling elements by stroke color in an SVG string.
+   * @param {string} svgString
+   * @returns A SVG string with sibling elements grouped by stroke color.
+   */
+  function getSvgStrGroupByStrokeColor(svgString) {
+    const doc = new DOMParser().parseFromString(svgString, "image/svg+xml");
+
+    function processElement(element) {
+      const children = Array.from(element.children);
+      const colorGroups = new Map();
+      const nodesToRemove = [];
+      
+      children.forEach((child) => processElement(child));
+      
+      children.forEach((child) => {
+        const strokeColor = getStrokeColor(child);
+        if (strokeColor && child.tagName !== 'g') {
+          if (!colorGroups.has(strokeColor)) {
+            colorGroups.set(strokeColor, []);
+          }
+          colorGroups.get(strokeColor).push(child);
+          nodesToRemove.push(child);
+        }
+      });
+      
+      nodesToRemove.forEach((node) => {
+        const next = node.nextSibling;
+        // remove any empty text nodes left after the element to remove
+        if (next && next.nodeType === Node.TEXT_NODE && /^\s*$/.test(next.nodeValue)) {
+          element.removeChild(next);
+        }
+        element.removeChild(node);
+      });
+      
+      colorGroups.forEach((elements, color) => {
+        if (elements.length > 0) {
+          const group = doc.createElementNS("http://www.w3.org/2000/svg", "g");
+          group.setAttribute('id', `stroke-color-${color.replace(/[^a-zA-Z0-9]/g, '-')}`);
+          element.appendChild(group);
+          elements.forEach(elem => {
+            group.appendChild(elem);
+          });
+        }
+      });
+    }
+
+    processElement(doc.documentElement);
+    return new XMLSerializer().serializeToString(doc);
+  }
+
+  function getStrokeColor(element) {
+    if (element.hasAttribute('stroke')) {
+      const stroke = element.getAttribute('stroke');
+      if (stroke && stroke !== 'none') {
+        return stroke;
+      }
+    }
+    
+    if (element.hasAttribute('style')) {
+      const style = element.getAttribute('style');
+      const strokeMatch = style.match(/stroke\s*:\s*([^;]+)/);
+      if (strokeMatch && strokeMatch[1] && strokeMatch[1].trim() !== 'none') {
+        return strokeMatch[1].trim();
+      }
+    }
+    
+    return null;
+  }
 
   /** 
    * @private
@@ -1771,6 +1846,20 @@
       _svgMergeNamedGroups = true; 
     } else {
       _svgMergeNamedGroups = false; 
+    }
+  }
+
+
+  /**
+   * Set whether or not to group elements by stroke color. 
+   * @param {boolean} bEnabled - Enable or disables grouping of elements by stroke color.
+   * Default is `false`: elements with the same stroke color, at the same level, will be grouped.
+   */
+  p5plotSvg.setSvgGroupByStrokeColor = function(bEnabled) {
+    if (bEnabled === true){
+      _svgGroupByStrokeColor = true; 
+    } else {
+      _svgGroupByStrokeColor = false; 
     }
   }
 
@@ -3030,6 +3119,7 @@
   global.setSvgResolutionDPCM = p5plotSvg.setSvgResolutionDPCM;
   global.setSvgDefaultStrokeWeight = p5plotSvg.setSvgDefaultStrokeWeight;
   global.setSvgMergeNamedGroups = p5plotSvg.setSvgMergeNamedGroups;
+  global.setSvgGroupByStrokeColor = p5plotSvg.setSvgGroupByStrokeColor;
   global.setSvgDefaultStrokeColor = p5plotSvg.setSvgDefaultStrokeColor;
   global.setSvgBackgroundColor = p5plotSvg.setSvgBackgroundColor;
   global.setSvgIndent = p5plotSvg.setSvgIndent;


### PR DESCRIPTION
This PR implements #12 

The goal of this change is to allow automatic grouping of sibling elements with the same stroke color as a post-processing step. In the real world this reduce the time to production for pen plotter artist that layer multiple colors, generating files that are ready to plot without further modification.

This has the other advantage to enable grouping in existing sketches without having to modify the `draw()` function, (assuming stroke color was already properly set).

See example provided below.

## Changes
- Adds new public setting setSvgGroupByStrokeColor which is disabled by default
- Adds new private function getSvgStrGroupByStrokeColor which serves as a post-processing option in exportSVG

## Testing
Manual testing was done, see live P5 sketch example: https://editor.p5js.org/Ucodia/sketches/t4rsNH2-H